### PR TITLE
Fix docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ dbdata:
   image: andreagrandi/postgresql:9.3
   volumes:
     - /var/lib/postgresql
-  command: true
+  command: "true"
 
 db:
   image: andreagrandi/postgresql:9.3


### PR DESCRIPTION
docker-compose now requires the command between quotation marks.
